### PR TITLE
Run container with SYS_ADMIN capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     apt-get install -y curl sudo && \
     curl -L https://zoom.us/client/latest/zoom_amd64.deb > /tmp/zoom.deb && \
     apt-get install -y --no-install-recommends /tmp/zoom.deb && \
-    apt-get install -y --no-install-recommends libnss3 pulseaudio-utils libasound2 && \
+    apt-get install -y --no-install-recommends libnss3 pulseaudio-utils libasound2 libgl1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM debian:bookworm
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -y curl sudo && \
+    apt-get upgrade -y && \
+    apt-get install -y curl && \
     curl -L https://zoom.us/client/latest/zoom_amd64.deb > /tmp/zoom.deb && \
     apt-get install -y --no-install-recommends /tmp/zoom.deb && \
     apt-get install -y --no-install-recommends libnss3 pulseaudio-utils libasound2 libgl1 && \

--- a/run-zoom.sh
+++ b/run-zoom.sh
@@ -24,6 +24,7 @@ if docker container inspect ${CONTAINER_NAME} 2>/dev/null >/dev/null; then
     docker container exec ${CONTAINER_NAME} zoom "$@"
 else
     docker run --rm \
+	--cap-add SYS_ADMIN \
 	--net=host \
 	--name ${CONTAINER_NAME} \
 	-e DISPLAY=${DISPLAY} \


### PR DESCRIPTION
... and update base image to latest stable Debian release (bookworm)

The --add-cap change fixes the following error that I get when running latest zoom with debian bullseye and bookworm releases:

    Failed to move to new namespace: PID namespaces supported, Network
    namespace supported, but failed: errno = Operation not permitted